### PR TITLE
Specify 'type' for '<input>' elements

### DIFF
--- a/exponentialidle/stars.html
+++ b/exponentialidle/stars.html
@@ -62,10 +62,10 @@
     <p class="stars-par text-color">For f(t), type the number after ee. Use the price of the next cheapest f(t) purchase. Make sure you have purchased all variables and upgrades that cost less than this input.</p>
     <p class="stars-par text-color">For stars, make sure this is the number of stars you can spend only on permanent levels, i.e., excluding variable and automation purchases.</p>
     <p class="stars-par text-color">For Supremacy upgrade, enter the highest level of the third Supremacy upgrade (the one that initially costs 1e110ψ). You won't see this upgrade unless you bought all levels of the "y exponent" upgrade. Leave the field blank if you don't have access to this upgrade yet or if you want it to be deduced from f(t).</p>
-    <input class="color-medium stars-input" id="ft" rows="1" placeholder="Your f(t) here!" spellcheck="false" />
-    <input class="color-medium stars-input" id="stars" rows="1" placeholder="Your stars here!" spellcheck="false" />
-    <input class="color-medium stars-input" id="upgrade" rows="1" placeholder="Your Supremacy upgrade level here! (Leave blank for automatic)" spellcheck="false" />
-    
+    <input type="number" class="color-medium stars-input" id="ft" rows="1" placeholder="Your f(t) here!" spellcheck="false" />
+    <input type="number" class="color-medium stars-input" id="stars" rows="1" placeholder="Your stars here!" spellcheck="false" />
+    <input type="number" class="color-medium stars-input" id="upgrade" rows="1" placeholder="Your Supremacy upgrade level here! (Leave blank for automatic)" spellcheck="false" />
+
     <div id="buttons" height="50">
     <button id="distribute" class="stars-button color-light" onclick="distribute()">Distribute!</button>
     </div>

--- a/exponentialidle/students.html
+++ b/exponentialidle/students.html
@@ -86,13 +86,13 @@
       regularly, not if you only use it once in a while. The acceleration
       multiplier will default to about 2.85x, but can be changed to your liking.
     </p>
-    <input class="color-medium stars-input" rows="1" id="students" placeholder="Your students here" spellcheck="false">
-    <input class="color-medium stars-input" rows="1" id="t" placeholder="Your t here" spellcheck="false">
-    <input class="color-medium stars-input" rows="1" id="ft" placeholder="Your f(t) here" spellcheck="false">
-    <input class="color-medium stars-input" rows="1" id="stars" placeholder="Your stars here" spellcheck="false">
-    <input class="color-medium stars-input" style="display:none" rows="1" id="theories" placeholder="Theories unlocked (default 0)" spellcheck="false">
-    <input class="color-medium stars-input" style="display:none" rows="1" id="theoryboosts" placeholder="Theory boost upgrades bought (default 0)" spellcheck="false">
-    <input class="color-medium stars-input" rows="1" id="accelmult" placeholder="Your acceleration multiplier here (optional)" spellcheck="false">
+    <input type="number" class="color-medium stars-input" rows="1" id="students" placeholder="Your students here" spellcheck="false">
+    <input type="number" class="color-medium stars-input" rows="1" id="t" placeholder="Your t here" spellcheck="false">
+    <input type="number" class="color-medium stars-input" rows="1" id="ft" placeholder="Your f(t) here" spellcheck="false">
+    <input type="number" class="color-medium stars-input" rows="1" id="stars" placeholder="Your stars here" spellcheck="false">
+    <input type="number" class="color-medium stars-input" style="display:none" rows="1" id="theories" placeholder="Theories unlocked (default 0)" spellcheck="false">
+    <input type="number" class="color-medium stars-input" style="display:none" rows="1" id="theoryboosts" placeholder="Theory boost upgrades bought (default 0)" spellcheck="false">
+    <input type="number" class="color-medium stars-input" rows="1" id="accelmult" placeholder="Your acceleration multiplier here (optional)" spellcheck="false">
     <div class="students-cb-container">
       <div style="display:inline-block">
 	    <label class="text-color noselect" for="adbonus">Ad Bonus</label>


### PR DESCRIPTION
On devices with dynamic keyboards (like mobile devices), an `<input type="number />` will render a number-pad keyboard by default.

This is a recreation of https://github.com/conicgames/conicgames.github.io/pull/2 since the default branch had its history rewritten (force push).